### PR TITLE
Remove the extra / at the end of the directory (Fixes #6)

### DIFF
--- a/src/main/java/analyzer/exercises/Exercise.java
+++ b/src/main/java/analyzer/exercises/Exercise.java
@@ -25,7 +25,7 @@ public abstract class Exercise {
         this.statusObject.put("comments", this.comments);
 
         try {
-            this.cu = JavaParser.parse(new File(dir + "/src/main/java/" + solutionFile));
+            this.cu = JavaParser.parse(new File(dir + "src/main/java/" + solutionFile));
         } catch (ParseProblemException e) {
             this.statusObject.put("status", "disapprove_with_comment");
             this.comments.put("java.general.failedParse");


### PR DESCRIPTION
Remove the / which is already trailing on the supplied directory path. Fixes #6.

NOTE: issue was closed prematurely since we thought we had the directory structure, but it looks like we were wrong about the path.