### PR TITLE
Use "approve" and "disapprove" rather than existing statuses (Fixes #11)

### DIFF
--- a/src/main/java/analyzer/exercises/Exercise.java
+++ b/src/main/java/analyzer/exercises/Exercise.java
@@ -27,7 +27,7 @@ public abstract class Exercise {
         try {
             this.cu = JavaParser.parse(new File(dir + "src/main/java/" + solutionFile));
         } catch (ParseProblemException e) {
-            this.statusObject.put("status", "disapprove_with_comment");
+            this.statusObject.put("status", "disapprove");
             this.comments.put("java.general.failedParse");
         } catch (FileNotFoundException e) {
             this.statusObject.put("status", "refer_to_mentor");

--- a/src/main/java/analyzer/exercises/Twofer.java
+++ b/src/main/java/analyzer/exercises/Twofer.java
@@ -21,35 +21,30 @@ public class Twofer extends Exercise {
             this.cu.walk(walker);
 
             if (!(walker.hasClassTwofer && walker.hasMethodTwofer)) {
-                this.statusObject.put("status", "disapprove_with_comment");
+                this.statusObject.put("status", "disapprove");
                 this.comments.put("java.general.properClassAndMethodNames");
             } else if (walker.hasHardCodedTestCases) {
-                this.statusObject.put("status", "disapprove_with_comment");
+                this.statusObject.put("status", "disapprove");
                 this.comments.put("java.general.hardCodedTestCases");
             } else if (walker.usesLambda) {
                 this.statusObject.put("status", "refer_to_mentor");
             } else if (walker.usesLoops) {
                 this.statusObject.put("status", "refer_to_mentor");
             } else if (!walker.hasMethodCall && !(walker.usesIfStatement || walker.usesConditional)) {
-                this.statusObject.put("status", "disapprove_with_comment");
+                this.statusObject.put("status", "disapprove");
                 this.comments.put("java.two-fer.noConditionsOrMethodCalls");
             } else if (walker.usesFormat) {
-                this.statusObject.put("status", "disapprove_with_comment");
+                this.statusObject.put("status", "disapprove");
                 this.comments.put("java.two-fer.stringFormatPerformance");
             } else if (walker.returnCount > 1) {
-                this.statusObject.put("status", "disapprove_with_comment");
+                this.statusObject.put("status", "disapprove");
                 this.comments.put("java.two-fer.multipleReturns");
             } else {
                 if (walker.usesIfStatement) {
                     this.comments.put("java.two-fer.useTernaryExpression");
                 }
 
-                if (this.comments.length() == 0) {
-                    this.statusObject.put("status", "approve_as_optimal");
-                } else {
-                    this.statusObject.put("status", "approve_with_comment");
-                }
-            }
+                this.statusObject.put("status", "approve");            }
         }
     }
 }

--- a/src/main/java/analyzer/exercises/Twofer.java
+++ b/src/main/java/analyzer/exercises/Twofer.java
@@ -44,7 +44,8 @@ public class Twofer extends Exercise {
                     this.comments.put("java.two-fer.useTernaryExpression");
                 }
 
-                this.statusObject.put("status", "approve");            }
+                this.statusObject.put("status", "approve");
+            }
         }
     }
 }


### PR DESCRIPTION
Use "approve" and "disapprove" rather than "approve_as_optimal", "approve_with_comment", and "disapprove_with_comment". Fixes #11 