### PR TITLE
Correct typo for ternary operator comment

### DIFF
--- a/src/main/java/analyzer/exercises/Twofer.java
+++ b/src/main/java/analyzer/exercises/Twofer.java
@@ -49,7 +49,7 @@ public class Twofer extends Exercise {
                 this.comments.put("java.two-fer.use_one_return");
             } else {
                 if (walker.usesIfStatement) {
-                    this.comments.put("java.two-fer.use_ternary_expression");
+                    this.comments.put("java.two-fer.use_ternary_operator");
                 }
 
                 this.statusObject.put("status", "approve");


### PR DESCRIPTION
use_ternary_expression => use_ternary_operator since the file is https://github.com/exercism/website-copy/blob/master/automated-comments/java/two-fer/use_ternary_operator.md