### PR TITLE
Get names for long constructors and methods

### DIFF
--- a/src/main/java/analyzer/exercises/GeneralComment.java
+++ b/src/main/java/analyzer/exercises/GeneralComment.java
@@ -11,6 +11,8 @@ public enum GeneralComment implements Comment {
 
     public static String CLASS_NAME = "className";
     public static String METHOD_NAME = "methodName";
+    public static String CONSTRUCTOR_NAMES = "constructorNames";
+    public static String METHOD_NAMES = "methodNames";
 
     @Override
     public String toJson() {

--- a/src/main/java/analyzer/exercises/hamming/Hamming.java
+++ b/src/main/java/analyzer/exercises/hamming/Hamming.java
@@ -9,6 +9,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 
 import java.io.File;
+import java.util.Set;
 
 public class Hamming extends Exercise {
     public Hamming(String dir) {
@@ -95,14 +96,30 @@ public class Hamming extends Exercise {
             addComment(HammingComment.SHOULD_USE_STREAM_FILTER_AND_COUNT);
         }
 
-        if (walker.hasLongConstructor()) {
-            addComment(GeneralComment.CONSTRUCTOR_TOO_LONG);
+        Set<String> longConstructors = walker.getLongConstructors();
+        if (!longConstructors.isEmpty()) {
+            addComment(
+                GeneralComment.CONSTRUCTOR_TOO_LONG,
+                Params.newBuilder()
+                    .addParam(
+                        GeneralComment.CONSTRUCTOR_NAMES, formatNames(longConstructors))
+                    .build());
         }
 
-        if (walker.hasLongMethod()) {
-            addComment(GeneralComment.METHOD_TOO_LONG);
+        Set<String> longMethods = walker.getLongMethods();
+        if (!longMethods.isEmpty()) {
+            addComment(
+                GeneralComment.METHOD_TOO_LONG,
+                Params.newBuilder()
+                    .addParam(
+                        GeneralComment.METHOD_NAMES, formatNames(longMethods))
+                    .build());
         }
 
         setStatus(Status.APPROVE);
+    }
+
+    private static String formatNames(Set<String> names) {
+        return String.join(", ", names);
     }
 }

--- a/src/main/java/analyzer/exercises/hamming/HammingWalker.java
+++ b/src/main/java/analyzer/exercises/hamming/HammingWalker.java
@@ -1,5 +1,7 @@
 package analyzer.exercises.hamming;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
@@ -272,12 +274,18 @@ class HammingWalker implements Consumer<ClassOrInterfaceDeclaration> {
         return !statement.findAll(LambdaExpr.class).isEmpty();
     }
 
-    public boolean hasLongConstructor() {
-        return constructors.stream().anyMatch(this::isLongNode);
+    public Set<String> getLongConstructors() {
+        return constructors.stream()
+            .filter(this::isLongNode)
+            .map(ConstructorDeclaration::getNameAsString)
+            .collect(toImmutableSet());
     }
 
-    public boolean hasLongMethod() {
-        return methods.values().stream().anyMatch(this::isLongNode);
+    public Set<String> getLongMethods() {
+        return methods.values().stream()
+            .filter(this::isLongNode)
+            .map(MethodDeclaration::getNameAsString)
+            .collect(toImmutableSet());
     }
 
     private boolean isLongNode(NodeWithRange<?> node) {

--- a/src/test/java/analyzer/exercises/hamming/HammingTest.java
+++ b/src/test/java/analyzer/exercises/hamming/HammingTest.java
@@ -47,7 +47,9 @@ public class HammingTest {
                             .put(
                                 new JSONObject()
                                     .put("comment", "java.general.use_proper_method_name")
-                                    .put("params", new JSONObject().put("methodName", "getHammingDistance"))))
+                                    .put(
+                                        "params",
+                                        new JSONObject().put("methodName", "getHammingDistance"))))
                     .toString(INDENTATION_LEVEL));
     }
 
@@ -144,7 +146,8 @@ public class HammingTest {
                     .put("status", "disapprove")
                     .put(
                         "comments",
-                        new JSONArray().put("java.hamming.must_use_string_char_at_or_code_point_at"))
+                        new JSONArray().put(
+                            "java.hamming.must_use_string_char_at_or_code_point_at"))
                     .toString(INDENTATION_LEVEL));
     }
 
@@ -238,10 +241,16 @@ public class HammingTest {
         assertThat(hamming.getAnalysis().toString(INDENTATION_LEVEL))
             .isEqualTo(
                 new JSONObject()
-                    .put("status", "approve")
-                    .put(
-                        "comments",
-                        new JSONArray().put("java.general.constructor_too_long"))
+                .put("status", "approve")
+                .put("comments",
+                    new JSONArray()
+                        .put(
+                            new JSONObject()
+                                .put("comment", "java.general.constructor_too_long")
+                                .put(
+                                    "params",
+                                    new JSONObject().put(
+                                        "constructorNames", "Hamming"))))
                     .toString(INDENTATION_LEVEL));
     }
 
@@ -256,9 +265,15 @@ public class HammingTest {
             .isEqualTo(
                 new JSONObject()
                     .put("status", "approve")
-                    .put(
-                        "comments",
-                        new JSONArray().put("java.general.method_too_long"))
+                    .put("comments",
+                        new JSONArray()
+                            .put(
+                                new JSONObject()
+                                    .put("comment", "java.general.method_too_long")
+                                    .put(
+                                        "params",
+                                        new JSONObject().put(
+                                            "methodNames", "calculateHammingDistance"))))
                     .toString(INDENTATION_LEVEL));
     }
 


### PR DESCRIPTION
As requested in the comments review, we want to send the names for constructors and methods that are too long. While I do not expect the analyzer to typically find more than one, it is nice to have support for finding more than one.