### PR TITLE
Refactor Exercise not to handle file writing

### DIFF
--- a/src/main/java/analyzer/Main.java
+++ b/src/main/java/analyzer/Main.java
@@ -1,20 +1,30 @@
 package analyzer;
 
 import analyzer.exercises.Exercise;
-import analyzer.exercises.twofer.Twofer;
-import analyzer.exercises.hamming.Hamming;
+import analyzer.exercises.SupportedExercise;
+import org.json.JSONObject;
 
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 
 public class Main {
+    public static final String SOLUTION_FILE_RELATIVE_PATH = "src/main/java/";
+    private static final String ANALYSIS_FILE_NAME = "analysis.json";
+
     private static boolean isNotValidDirectory(String p) {
         return !p.endsWith("/") || !new File(p).isDirectory();
     }
 
+    private static void exitNonZero(String message) {
+        System.err.println(message);
+        System.exit(-1);
+    }
+
     public static void main(String... args) {
-        if (args.length < 3) {
-            System.err.println("Invalid arguments. Usage: java-analyzer <exercise slug> <exercise directory> <output directory>");
-            System.exit(-1);
+        if (args.length != 3) {
+            exitNonZero("Invalid arguments. Usage: java-analyzer <exercise slug> <exercise directory> <output directory>");
         }
 
         String slug = args[0];
@@ -22,29 +32,47 @@ public class Main {
         String outputDirectory = args[2];
 
         if (isNotValidDirectory(inputDirectory)) {
-            System.err.println("Invalid input directory. Must be a valid directory and end with a slash.");
-            System.exit(-1);
+            exitNonZero("Invalid input directory. Must be a valid directory and end with a slash.");
         }
         if (isNotValidDirectory(outputDirectory)) {
-            System.err.println("Invalid output directory. Must be a valid directory and end with a slash.");
-            System.exit(-1);
+            exitNonZero("Invalid output directory. Must be a valid directory and end with a slash.");
         }
 
+        SupportedExercise exercise = SupportedExercise.getBySlug(slug);
+        if (exercise == null) {
+            exitNonZero("The exercise is invalid or not yet supported.");
+        }
+
+        File solutionFile = new File(inputDirectory
+                + SOLUTION_FILE_RELATIVE_PATH
+                + exercise.fileName);
+
         Exercise ex = null;
-        switch (slug) {
-            case "two-fer":
-                ex = new Twofer(inputDirectory, outputDirectory);
-                break;
-            case "hamming":
-                ex = new Hamming(inputDirectory, outputDirectory);
-                break;
-            default:
-                System.err.println("Exercise not found");
-                System.exit(-1);
+        try {
+            @SuppressWarnings("unchecked")
+            Class<? extends Exercise> exerciseClass =
+                    (Class<? extends Exercise>) Class.forName(exercise.className);
+            ex = exerciseClass.getConstructor(File.class).newInstance(solutionFile);
+        } catch (ClassNotFoundException
+                | NoSuchMethodException
+                | InstantiationException
+                | IllegalAccessException
+                | InvocationTargetException e) {
+            e.printStackTrace();
+            exitNonZero("Failed to instantiate the analyzer for this exercise.");
         }
 
         ex.parse();
-        ex.writeAnalysisToFile();
-        System.out.println("Analysis completed successfully");
+        JSONObject analysis = ex.getAnalysis();
+
+        try (FileWriter fw = new FileWriter(outputDirectory + ANALYSIS_FILE_NAME)) {
+            fw.write(analysis.toString());
+            fw.flush();
+        } catch (IOException e) {
+            e.printStackTrace();
+            exitNonZero("Failed to write output file.");
+        }
+
+        System.out.println("Analysis completed successfully.");
     }
 }

--- a/src/main/java/analyzer/Statistics.java
+++ b/src/main/java/analyzer/Statistics.java
@@ -3,12 +3,13 @@ package analyzer;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import analyzer.exercises.Exercise;
-import analyzer.exercises.Exercise.WriteAnalysisToFile;
+import analyzer.exercises.SupportedExercise;
 import analyzer.exercises.twofer.Twofer;
 import analyzer.exercises.hamming.Hamming;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -16,7 +17,6 @@ import java.util.Random;
 import java.util.function.Function;
 
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.SetMultimap;
@@ -26,20 +26,24 @@ public class Statistics {
         SetMultimap<String, Integer> archiveByComment = HashMultimap.create();
         List<Integer> passingArchives = new ArrayList<>();
 
-        String slug = args.length > 0 ? args[0] : "hamming";
-        Function<String, Exercise> constructor;
-        switch(slug) {
-            case "hamming":
-                constructor = dir -> new Hamming(dir, WriteAnalysisToFile.NO);
+        SupportedExercise exercise = args.length > 0 ? SupportedExercise.getBySlug(args[0]) : SupportedExercise.HAMMING;
+        Function<File, Exercise> constructor;
+        switch(exercise) {
+            case HAMMING:
+                constructor = Hamming::new;
                 break;
-            case "twofer": // fallthrough
+            case TWO_FER: // fallthrough
             default:
-                slug = "twofer";
-                constructor = dir -> new Twofer(dir, WriteAnalysisToFile.NO);
+                exercise = SupportedExercise.TWO_FER;
+                constructor = Twofer::new;
         }
 
         for (int archive = 0; archive < 500; archive++) {
-            Exercise ex = constructor.apply("archive/" + slug + "/" + archive + "/");
+            Exercise ex = constructor.apply(new File("archive/"
+                    + exercise.slug
+                    + "/" + archive
+                    + "/" + Main.SOLUTION_FILE_RELATIVE_PATH
+                    + exercise.fileName));
             ex.parse();
             JSONObject analysis = ex.getAnalysis();
             if (!analysis.has("comments")) {

--- a/src/main/java/analyzer/exercises/Exercise.java
+++ b/src/main/java/analyzer/exercises/Exercise.java
@@ -43,10 +43,6 @@ public abstract class Exercise {
     }
 
     protected void addComment(Comment comment, Params params) {
-        if (params.isEmpty()) {
-            this.analysis.append(COMMENTS, comment.toJson());
-            return;
-        }
         this.analysis.append(
             COMMENTS,
             new JSONObject()

--- a/src/main/java/analyzer/exercises/Exercise.java
+++ b/src/main/java/analyzer/exercises/Exercise.java
@@ -7,81 +7,25 @@ import org.json.JSONObject;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileWriter;
-import java.io.IOException;
 
 public abstract class Exercise {
     private static final String COMMENTS = "comments";
     private static final String COMMENT = "comment";
     private static final String PARAMS = "params";
-    private static final FileWriter NO_FILE_WRITER = null;
 
     private CompilationUnit compilationUnit;
-
     private final JSONObject analysis = new JSONObject();
-    private final FileWriter fileWriter;
-
-    public enum WriteAnalysisToFile {YES, NO}
-
-    protected Exercise(String directory,
-                       String solutionFile,
-                       String outputDirectory,
-                       WriteAnalysisToFile writeAnalysisToFile) {
-        this(getSolutionFile(directory, solutionFile),
-                getFileWriter(outputDirectory, writeAnalysisToFile));
-    }
 
     protected Exercise(File solutionFile) {
-        this(solutionFile, NO_FILE_WRITER);
-    }
-
-    private Exercise(File solutionFile, FileWriter fileWriter) {
-        this.fileWriter = fileWriter;
-
         try {
             this.compilationUnit = JavaParser.parse(solutionFile);
         } catch (ParseProblemException e) {
             addComment(GeneralComment.FAILED_PARSE);
         } catch (FileNotFoundException e) {
-            addComment(
-                GeneralComment.FILE_NOT_FOUND,
-                Params.newBuilder().addParam("solutionFile", solutionFile.getName()).build());
-        }
-    }
-
-    /**
-     * @deprecated The output file should no longer be written in the input file directory
-     */
-    @Deprecated
-    protected Exercise(String directory, String solutionFile) {
-        this(directory, solutionFile, WriteAnalysisToFile.YES);
-    }
-
-    /**
-     * @deprecated The output file should no longer be written in the input file directory
-     */
-    @Deprecated
-    protected Exercise(String directory,
-                       String solutionFile,
-                       WriteAnalysisToFile writeAnalysisToFile) {
-        this(getSolutionFile(directory, solutionFile),
-                getFileWriter(directory, writeAnalysisToFile));
-    }
-
-    private static File getSolutionFile(String directory, String solutionFile) {
-        return new File(directory + "src/main/java/" + solutionFile);
-    }
-
-    private static FileWriter getFileWriter(
-        String directory, WriteAnalysisToFile writeAnalysisToFile) {
-        if (writeAnalysisToFile == WriteAnalysisToFile.NO) {
-            return null;
-        }
-        try {
-            return new FileWriter(directory + "analysis.json");
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
+            addComment(GeneralComment.FILE_NOT_FOUND,
+                    Params.newBuilder()
+                            .addParam("solutionFile", solutionFile.getName())
+                            .build());
         }
     }
 
@@ -92,7 +36,7 @@ public abstract class Exercise {
         parse(compilationUnit);
     }
 
-    abstract public void parse(CompilationUnit compilationUnit);
+    public abstract void parse(CompilationUnit compilationUnit);
 
     protected void addComment(Comment comment) {
         addComment(comment, Params.EMPTY);
@@ -112,18 +56,5 @@ public abstract class Exercise {
 
     public JSONObject getAnalysis() {
         return analysis;
-    }
-
-    public void writeAnalysisToFile() {
-        if (fileWriter == null) {
-            return;
-        }
-
-        try {
-            fileWriter.write(analysis.toString());
-            fileWriter.flush();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
     }
 }

--- a/src/main/java/analyzer/exercises/SupportedExercise.java
+++ b/src/main/java/analyzer/exercises/SupportedExercise.java
@@ -1,0 +1,31 @@
+package analyzer.exercises;
+
+import javax.annotation.Nullable;
+
+/**
+ * Enumeration of currently supported exercises.
+ */
+public enum SupportedExercise {
+    HAMMING("hamming", "Hamming.java", "analyzer.exercises.hamming.Hamming"),
+    TWO_FER("two-fer", "Twofer.java", "analyzer.exercises.twofer.Twofer");
+
+    public final String slug;
+    public final String fileName;
+    public final String className;
+
+    SupportedExercise(String slug, String fileName, String className) {
+        this.slug = slug;
+        this.fileName = fileName;
+        this.className = className;
+    }
+
+    public static @Nullable
+    SupportedExercise getBySlug(String slug) {
+        for (SupportedExercise v : SupportedExercise.values()) {
+            if (v.slug.equals(slug)) {
+                return v;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/analyzer/exercises/hamming/Hamming.java
+++ b/src/main/java/analyzer/exercises/hamming/Hamming.java
@@ -12,33 +12,6 @@ import java.util.Set;
 
 public class Hamming extends Exercise {
 
-    public Hamming(String inputDirectory, String outputDirectory) {
-        this(inputDirectory, outputDirectory, WriteAnalysisToFile.YES);
-    }
-
-    public Hamming(String inputDirectory,
-                   String outputDirectory,
-                   WriteAnalysisToFile writeAnalysisToFile) {
-        super(inputDirectory, "Hamming.java", outputDirectory, writeAnalysisToFile);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Deprecated
-    public Hamming(String inputDirectory) {
-        this(inputDirectory, WriteAnalysisToFile.YES);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Deprecated
-    public Hamming(String inputDirectory, WriteAnalysisToFile writeAnalysisToFile) {
-        super(inputDirectory, "Hamming.java", writeAnalysisToFile);
-    }
-
-    /** For testing. */
     public Hamming(File solutionFile) {
         super(solutionFile);
     }

--- a/src/main/java/analyzer/exercises/twofer/Twofer.java
+++ b/src/main/java/analyzer/exercises/twofer/Twofer.java
@@ -10,33 +10,6 @@ import analyzer.exercises.Params;
 
 public class Twofer extends Exercise {
 
-    public Twofer(String inputDirectory, String outputDirectory) {
-        this(inputDirectory, outputDirectory, WriteAnalysisToFile.YES);
-    }
-
-    public Twofer(String inputDirectory,
-                  String outputDirectory,
-                  WriteAnalysisToFile writeAnalysisToFile) {
-        super(inputDirectory, "Twofer.java", outputDirectory, writeAnalysisToFile);
-    }
-
-    /**
-     * @deprecated {@inheritDoc}
-     */
-    @Deprecated
-    public Twofer(String inputDirectory) {
-        this(inputDirectory, WriteAnalysisToFile.YES);
-    }
-
-    /**
-     * @deprecated {@inheritDoc}
-     */
-    @Deprecated
-    public Twofer(String inputDirectory, WriteAnalysisToFile writeAnalysisToFile) {
-        super(inputDirectory, "Twofer.java", writeAnalysisToFile);
-    }
-
-    /** For testing. */
     public Twofer(File solutionFile) {
         super(solutionFile);
     }

--- a/src/test/java/analyzer/exercises/hamming/HammingTest.java
+++ b/src/test/java/analyzer/exercises/hamming/HammingTest.java
@@ -58,10 +58,12 @@ public class HammingTest {
         hamming.parse();
 
         assertThat(hamming.getAnalysis().toString(INDENTATION_LEVEL))
-            .isEqualTo(
-                new JSONObject()
-                    .put("comments", new JSONArray().put("java.hamming.must_use_constructor"))
-                    .toString(INDENTATION_LEVEL));
+                .isEqualTo(new JSONObject()
+                        .put("comments", new JSONArray()
+                                .put(new JSONObject()
+                                        .put("comment", "java.hamming.must_use_constructor")
+                                        .put("params", new JSONObject())))
+                        .toString(INDENTATION_LEVEL));
     }
 
     @Test
@@ -71,13 +73,12 @@ public class HammingTest {
         hamming.parse();
 
         assertThat(hamming.getAnalysis().toString(INDENTATION_LEVEL))
-            .isEqualTo(
-                new JSONObject()
-                    .put(
-                        "comments",
-                        new JSONArray()
-                            .put("java.hamming.must_use_conditional_logic_in_constructor"))
-                    .toString(INDENTATION_LEVEL));
+                .isEqualTo(new JSONObject()
+                        .put("comments", new JSONArray()
+                                .put(new JSONObject()
+                                        .put("comment", "java.hamming.must_use_conditional_logic_in_constructor")
+                                        .put("params", new JSONObject())))
+                        .toString(INDENTATION_LEVEL));
     }
 
     @Test
@@ -87,12 +88,12 @@ public class HammingTest {
         hamming.parse();
 
         assertThat(hamming.getAnalysis().toString(INDENTATION_LEVEL))
-            .isEqualTo(
-                new JSONObject()
-                    .put(
-                        "comments",
-                        new JSONArray().put("java.hamming.must_throw_in_constructor"))
-                    .toString(INDENTATION_LEVEL));
+                .isEqualTo(new JSONObject()
+                        .put("comments", new JSONArray()
+                                .put(new JSONObject()
+                                        .put("comment", "java.hamming.must_throw_in_constructor")
+                                        .put("params", new JSONObject())))
+                        .toString(INDENTATION_LEVEL));
     }
 
     @Test
@@ -102,12 +103,12 @@ public class HammingTest {
         hamming.parse();
 
         assertThat(hamming.getAnalysis().toString(INDENTATION_LEVEL))
-            .isEqualTo(
-                new JSONObject()
-                    .put(
-                        "comments",
-                        new JSONArray().put("java.hamming.must_calculate_hamming_distance"))
-                    .toString(INDENTATION_LEVEL));
+                .isEqualTo(new JSONObject()
+                        .put("comments", new JSONArray()
+                                .put(new JSONObject()
+                                        .put("comment", "java.hamming.must_calculate_hamming_distance")
+                                        .put("params", new JSONObject())))
+                        .toString(INDENTATION_LEVEL));
     }
 
     @Test
@@ -117,12 +118,12 @@ public class HammingTest {
         hamming.parse();
 
         assertThat(hamming.getAnalysis().toString(INDENTATION_LEVEL))
-            .isEqualTo(
-                new JSONObject()
-                    .put(
-                        "comments",
-                        new JSONArray().put("java.hamming.avoid_character_literals"))
-                    .toString(INDENTATION_LEVEL));
+                .isEqualTo(new JSONObject()
+                        .put("comments", new JSONArray()
+                                .put(new JSONObject()
+                                        .put("comment", "java.hamming.avoid_character_literals")
+                                        .put("params", new JSONObject())))
+                        .toString(INDENTATION_LEVEL));
     }
 
     @Test
@@ -134,13 +135,12 @@ public class HammingTest {
         hamming.parse();
 
         assertThat(hamming.getAnalysis().toString(INDENTATION_LEVEL))
-            .isEqualTo(
-                new JSONObject()
-                    .put(
-                        "comments",
-                        new JSONArray().put(
-                            "java.hamming.must_use_string_char_at_or_code_point_at"))
-                    .toString(INDENTATION_LEVEL));
+                .isEqualTo(new JSONObject()
+                        .put("comments", new JSONArray()
+                                .put(new JSONObject()
+                                        .put("comment", "java.hamming.must_use_string_char_at_or_code_point_at")
+                                        .put("params", new JSONObject())))
+                        .toString(INDENTATION_LEVEL));
     }
 
     @Test
@@ -150,12 +150,12 @@ public class HammingTest {
         hamming.parse();
 
         assertThat(hamming.getAnalysis().toString(INDENTATION_LEVEL))
-            .isEqualTo(
-                new JSONObject()
-                    .put(
-                        "comments",
-                        new JSONArray().put("java.hamming.calculate_distance_in_constructor"))
-                    .toString(INDENTATION_LEVEL));
+                .isEqualTo(new JSONObject()
+                        .put("comments", new JSONArray()
+                                .put(new JSONObject()
+                                        .put("comment", "java.hamming.calculate_distance_in_constructor")
+                                        .put("params", new JSONObject())))
+                        .toString(INDENTATION_LEVEL));
     }
 
     @Test
@@ -177,12 +177,12 @@ public class HammingTest {
         hamming.parse();
 
         assertThat(hamming.getAnalysis().toString(INDENTATION_LEVEL))
-            .isEqualTo(
-                new JSONObject()
-                    .put(
-                        "comments",
-                        new JSONArray().put("java.hamming.should_use_string_is_empty"))
-                    .toString(INDENTATION_LEVEL));
+                .isEqualTo(new JSONObject()
+                        .put("comments", new JSONArray()
+                                .put(new JSONObject()
+                                        .put("comment", "java.hamming.should_use_string_is_empty")
+                                        .put("params", new JSONObject())))
+                        .toString(INDENTATION_LEVEL));
     }
 
     @Test
@@ -194,12 +194,12 @@ public class HammingTest {
         hamming.parse();
 
         assertThat(hamming.getAnalysis().toString(INDENTATION_LEVEL))
-            .isEqualTo(
-                new JSONObject()
-                    .put(
-                        "comments",
-                        new JSONArray().put("java.hamming.calculate_distance_in_constructor"))
-                    .toString(INDENTATION_LEVEL));
+                .isEqualTo(new JSONObject()
+                        .put("comments", new JSONArray()
+                                .put(new JSONObject()
+                                        .put("comment", "java.hamming.calculate_distance_in_constructor")
+                                        .put("params", new JSONObject())))
+                        .toString(INDENTATION_LEVEL));
     }
 
     @Test
@@ -211,12 +211,12 @@ public class HammingTest {
         hamming.parse();
 
         assertThat(hamming.getAnalysis().toString(INDENTATION_LEVEL))
-            .isEqualTo(
-                new JSONObject()
-                    .put(
-                        "comments",
-                        new JSONArray().put("java.hamming.calculate_distance_in_constructor"))
-                    .toString(INDENTATION_LEVEL));
+                .isEqualTo(new JSONObject()
+                        .put("comments", new JSONArray()
+                                .put(new JSONObject()
+                                        .put("comment", "java.hamming.calculate_distance_in_constructor")
+                                        .put("params", new JSONObject())))
+                        .toString(INDENTATION_LEVEL));
     }
 
     @Test
@@ -271,12 +271,12 @@ public class HammingTest {
         hamming.parse();
 
         assertThat(hamming.getAnalysis().toString(INDENTATION_LEVEL))
-            .isEqualTo(
-                new JSONObject()
-                    .put(
-                        "comments",
-                        new JSONArray().put("java.hamming.should_use_stream_filter_and_count"))
-                    .toString(INDENTATION_LEVEL));
+                .isEqualTo(new JSONObject()
+                        .put("comments", new JSONArray()
+                                .put(new JSONObject()
+                                        .put("comment", "java.hamming.should_use_stream_filter_and_count")
+                                        .put("params", new JSONObject())))
+                        .toString(INDENTATION_LEVEL));
     }
 
     @Test

--- a/src/test/java/analyzer/exercises/twofer/TwoferTest.java
+++ b/src/test/java/analyzer/exercises/twofer/TwoferTest.java
@@ -74,11 +74,12 @@ public class TwoferTest {
         twofer.parse();
 
         assertThat(twofer.getAnalysis().toString())
-            .isEqualTo(
-                new JSONObject()
-                    .put("comments",
-                        new JSONArray().put("java.general.avoid_hard_coded_test_cases"))
-                    .toString());
+                .isEqualTo(new JSONObject()
+                        .put("comments", new JSONArray()
+                                .put(new JSONObject()
+                                        .put("comment", "java.general.avoid_hard_coded_test_cases")
+                                        .put("params", new JSONObject())))
+                        .toString());
     }
 
     @Test
@@ -88,11 +89,12 @@ public class TwoferTest {
         twofer.parse();
 
         assertThat(twofer.getAnalysis().toString())
-            .isEqualTo(
-                new JSONObject()
-                    .put("comments",
-                        new JSONArray().put("java.two-fer.use_conditional_logic"))
-                    .toString());
+                .isEqualTo(new JSONObject()
+                        .put("comments", new JSONArray()
+                                .put(new JSONObject()
+                                        .put("comment", "java.two-fer.use_conditional_logic")
+                                        .put("params", new JSONObject())))
+                        .toString());
     }
 
     @Test
@@ -102,11 +104,12 @@ public class TwoferTest {
         twofer.parse();
 
         assertThat(twofer.getAnalysis().toString())
-            .isEqualTo(
-                new JSONObject()
-                    .put("comments",
-                        new JSONArray().put("java.two-fer.avoid_string_format"))
-                    .toString());
+                .isEqualTo(new JSONObject()
+                        .put("comments", new JSONArray()
+                                .put(new JSONObject()
+                                        .put("comment", "java.two-fer.avoid_string_format")
+                                        .put("params", new JSONObject())))
+                        .toString());
     }
 
     @Test
@@ -116,11 +119,12 @@ public class TwoferTest {
         twofer.parse();
 
         assertThat(twofer.getAnalysis().toString())
-            .isEqualTo(
-                new JSONObject()
-                    .put("comments",
-                        new JSONArray().put("java.two-fer.use_one_return"))
-                    .toString());
+                .isEqualTo(new JSONObject()
+                        .put("comments", new JSONArray()
+                                .put(new JSONObject()
+                                        .put("comment", "java.two-fer.use_one_return")
+                                        .put("params", new JSONObject())))
+                        .toString());
     }
 
     @Test
@@ -130,11 +134,12 @@ public class TwoferTest {
         twofer.parse();
 
         assertThat(twofer.getAnalysis().toString())
-            .isEqualTo(
-                new JSONObject()
-                    .put("comments",
-                        new JSONArray().put("java.two-fer.use_ternary_operator"))
-                    .toString());
+                .isEqualTo(new JSONObject()
+                        .put("comments", new JSONArray()
+                                .put(new JSONObject()
+                                        .put("comment", "java.two-fer.use_ternary_operator")
+                                        .put("params", new JSONObject())))
+                        .toString());
     }
 
     @Test


### PR DESCRIPTION
I did some refactoring. Opening a pull request for review.

I added an enum with the currently supported exercises and some relevant information, so the slug, class name, and file name, can be easily set there as constants together. Also, now it is possible to get the right exercise class through its class name which is available in the enum instead of through switch statements that need to be updated.

I refactored Exercise to only have one constructor and removed everything related to writing files in there. Reading and writing is done in the Main method. It is not needed anywhere else as far as I could tell.