### PR TITLE
Updating log levels analyzer to only analyze exercise default methods

### DIFF
--- a/src/main/java/analyzer/exercises/loglevels/LogLevelsAnalyzer.java
+++ b/src/main/java/analyzer/exercises/loglevels/LogLevelsAnalyzer.java
@@ -29,6 +29,7 @@ public class LogLevelsAnalyzer extends VoidVisitorAdapter<OutputCollector> imple
     private static final String LOG_LEVEL = "logLevel";
     private static final String FORMAT = "format";
     private static List<String> EXPECTED_METHODS = List.of("substring", "split");
+    private static final List<String> METHODS_TO_ANALYZE = List.of(MESSAGE, LOG_LEVEL, REFORMAT);
 
     @Override
     public void analyze(Solution solution, OutputCollector output) {
@@ -43,6 +44,10 @@ public class LogLevelsAnalyzer extends VoidVisitorAdapter<OutputCollector> imple
 
     @Override
     public void visit(MethodDeclaration node, OutputCollector output) {
+        if (!METHODS_TO_ANALYZE.contains(node.getNameAsString())) {
+            return;
+        }
+
         if (containsHarcodedString(node)) {
             output.addComment(new AvoidHardCodedTestCases());
             return;

--- a/src/test/java/analyzer/AnalyzerIntegrationTest.java
+++ b/src/test/java/analyzer/AnalyzerIntegrationTest.java
@@ -141,7 +141,8 @@ class AnalyzerIntegrationTest {
             "NotUsingExpectedMethodsOnLogLevel",
             "NotUsingExpectedMethodsOnMessage",
             "NotUsingExpectedMethodsOnLogLevelAndMessage",
-            "UsingStringFormat"
+            "UsingStringFormat",
+            "UsingExtraHelperMethod"
     })
     void loglevels(String scenario) throws IOException {
         var path = Path.of("log-levels", scenario + ".java");

--- a/src/test/resources/analyzer/AnalyzerIntegrationTest.loglevels.UsingExtraHelperMethod.approved.txt
+++ b/src/test/resources/analyzer/AnalyzerIntegrationTest.loglevels.UsingExtraHelperMethod.approved.txt
@@ -1,0 +1,11 @@
+{
+  "comments": [
+    {
+      "comment": "java.general.exemplar",
+      "params": {
+        "exerciseName": "Log Levels"
+      },
+      "type": "celebratory"
+    }
+  ]
+}

--- a/src/test/resources/scenarios/log-levels/UsingExtraHelperMethod.java
+++ b/src/test/resources/scenarios/log-levels/UsingExtraHelperMethod.java
@@ -1,0 +1,25 @@
+package scenarios.loglevels;
+
+public class LogLevels {
+
+    public static String message(String logLine) {
+        int startMessageIndex = logLine.indexOf("]:") + 2;
+        String result = logLine.substring(startMessageIndex, logLine.length());
+        return result.trim();
+    }
+    
+    public static String logLevel(String logLine) {
+        int startLevelIndex = logLine.indexOf("[") + 1;
+        int endLevelIndex = logLine.indexOf("]");
+        return logLine.substring(startLevelIndex, endLevelIndex).toLowerCase();
+    }
+    
+    public static String reformat(String logLine) {
+        return LogLevels.message(logLine) + " (" + LogLevels.logLevel(logLine) + ")";
+    }
+    
+    public static void result() {
+        String logLine = "[ERROR]: Invalid operation";
+        String formattedString =  LogLevels.reformat(logLine);
+    }
+}


### PR DESCRIPTION
closes [#176](https://github.com/exercism/java-analyzer/issues/176)

@sanderploegsma I guess this could be a great addition to all the analyzers, what do you think? Because triggering comments of helper methods seems pointless