### PR TITLE
ci(dependabot): change to monthly interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,20 +4,20 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: 'monthly'
     labels:
       - "x:size/tiny"
 
   - package-ecosystem: gradle
     directory: "/"
     schedule:
-      interval: weekly
+      interval: 'monthly'
     labels:
       - "x:size/small"
 
   - package-ecosystem: docker
     directory: "/"
     schedule:
-      interval: weekly
+      interval: 'monthly'
     labels:
       - "x:size/small"


### PR DESCRIPTION
This PR changes the interval for dependabot updates to monthly.

Right now, the interval is usually set to daily, which results in (almost) daily notifications for Exercism maintainers, and frequent Docker updates to all tooling repos.

To reduce the maintenance burden, we are lowering the frequency to monthly. Due to Exercism's setup, it is unlikely that dependabot issues in our repositories need to be handled with any urgency, so we consider this to be a wise tradeoff.

For maintained track repos, maintainers can choose to close this PR unmerged. But for tooling repos and unmaintained tracks, we are requiring it to be merged.

Thanks!