### PR TITLE
Fix Gradle deprecated warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,13 +29,13 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
-shadowJar {
+def analyzerJar = shadowJar {
     mergeServiceFiles()
     archiveFileName.set("java-analyzer.jar")
 }
 
-artifacts {
-    archives shadowJar
+tasks.named("assemble") {
+    dependsOn(analyzerJar)
 }
 
 test {


### PR DESCRIPTION
This fixes the following Gradle warning:

```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/9.1.0/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
```

The exact error causing this:

```
> Configure project :
Build file '/home/runner/work/exercism-java-analyzer/exercism-java-analyzer/build.gradle': line 38
The archives configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 10. Add artifacts as direct task dependencies of the 'assemble' task instead of declaring them in the archives configuration. Consult the upgrading guide for further information: https://docs.gradle.org/9.3.1/userguide/upgrading_version_9.html#sec:archives-configuration
	at build_do7k9p1y1xiza2diu02pda9w5$_run_closure5.doCall$original(/home/runner/work/exercism-java-analyzer/exercism-java-analyzer/build.gradle:38)
	(Run with --stacktrace to get the full stack trace of this deprecation warning.)
```

CI example where this is occurring: https://github.com/exercism/java-analyzer/actions/runs/21577725341/job/62168545015#step:4:279