### PR TITLE
Bump eclipse-temurin from 25.0.3_9-jdk to 26.0.1_8-jdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY --chown=gradle:gradle . /app
 RUN gradle -i --stacktrace clean build shadowJar
 
-FROM eclipse-temurin:25.0.3_9-jdk@sha256:e23592541431eaeef5c13c84c21db71f97cdca0e70181ea6222ec9bccac24f6c
+FROM eclipse-temurin:26.0.1_8-jdk@sha256:e1ccbf158a2818db7f770d0159f30a191e512c6a482797c55f7ae04a54247563
 
 WORKDIR /opt/analyzer
 COPY bin/run.sh bin/run.sh


### PR DESCRIPTION
This lines up with https://github.com/exercism/java-representer/pull/297